### PR TITLE
database: increase arg field size

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-samba-audit-conf
+++ b/root/etc/e-smith/events/actions/nethserver-samba-audit-conf
@@ -40,4 +40,4 @@ if [[ $res == '0' ]]; then
 fi
 
 # Fix issue NethServer/dev#6572
-/usr/bin/mysql --defaults-file=/root/.my.cnf smbaudit -e "alter table audit modify column arg varchar(8702);"
+/usr/bin/mysql --defaults-file=/root/.my.cnf smbaudit -e "alter table audit modify column arg varchar(8703);"

--- a/root/etc/e-smith/events/actions/nethserver-samba-audit-conf
+++ b/root/etc/e-smith/events/actions/nethserver-samba-audit-conf
@@ -38,3 +38,6 @@ res=`/usr/bin/mysql --defaults-file=/root/.my.cnf -e "select count(*) from infor
 if [[ $res == '0' ]]; then
     /usr/bin/mysql --defaults-file=/root/.my.cnf < /usr/share/smbaudit/sql/smbaudit.sql
 fi
+
+# Fix issue NethServer/dev#6572
+/usr/bin/mysql --defaults-file=/root/.my.cnf smbaudit -e "alter table audit modify column arg varchar(8702);"


### PR DESCRIPTION
The arg field must contain 2 full path in case of
rename action.

Linux has a limit of 4096 bytes for the path name, plus 255 bytes for the file name.
The field must contain both file names plus a | char,
so the maximum total length should be ((4096+255)*2)+1 = 8703.

NethServer/dev#6572